### PR TITLE
Make sure arguments to `mix compile` are preserved

### DIFF
--- a/include/rebar3_elixir.hrl
+++ b/include/rebar3_elixir.hrl
@@ -28,15 +28,21 @@
   end
 
   defp aliases do
-    [compile: [&pre_compile_hooks/1, \"compile\", &post_compile_hooks/1]]
+    [compile: &compile_with_hooks/1]
   end
 
-  defp pre_compile_hooks(_) do
+  defp compile_with_hooks(args) do
+    pre_compile_hooks()
+    :ok = Mix.Task.run(\"compile\", args)
+    post_compile_hooks()
+  end
+
+  defp pre_compile_hooks() do
     run_hook_cmd [~s
     ]
   end
 
-  defp post_compile_hooks(_) do
+  defp post_compile_hooks() do
     run_hook_cmd [~s
     ]
   end


### PR DESCRIPTION
Fixes #1.