### PR TITLE
Fix compile hooks (again): do not break on no-op compile

### DIFF
--- a/include/rebar3_elixir.hrl
+++ b/include/rebar3_elixir.hrl
@@ -33,8 +33,9 @@
 
   defp compile_with_hooks(args) do
     pre_compile_hooks()
-    :ok = Mix.Task.run(\"compile\", args)
+    result = Mix.Task.run(\"compile\", args)
     post_compile_hooks()
+    result
   end
 
   defp pre_compile_hooks() do


### PR DESCRIPTION
If the compile task has nothing to do it returns `:noop`, not `:ok`.